### PR TITLE
removed pipes

### DIFF
--- a/elixir-patrick/run.exs
+++ b/elixir-patrick/run.exs
@@ -1,1 +1,1 @@
-2..100|>Enum.reduce(&*/2)|>Integer.digits|>Enum.sum|>IO.puts
+IO.puts Enum.sum Integer.digits(Enum.reduce(2..100,&*/2))


### PR DESCRIPTION
By removing the pipeline operators, I saved 3 characters.